### PR TITLE
Maintenance work on repo

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -1,0 +1,17 @@
+name: Zooni CI
+on:
+  pull_request:
+  push: { branches: master }
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.1
-before_install: gem install bundler -v 1.10.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.7-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      # git is required for installing gems
+      git && \
+      apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ADD ./Gemfile /app/
+ADD ./faraday-panoptes.gemspec /app/
+ADD ./ /app
+
+# ensure we use a newer version of rubygems / bundler
+RUN gem update --system
+
+RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This gem gives you a set of middleware that lets you use the Zooniverse Panoptes
 
 ```ruby
 api_client = Faraday.new(url: "https://panoptes.zooniverse.org") do |faraday|
-  faraday.adapter Faraday.default_adapter # WITHOUT THIS LINE NOTHING WILL HAPPEN
-  
   faraday.request :panoptes_client_credentials, url: 'https://panoptes.zooniverse.org', client_id: 'APPLICATION_ID', client_secret: 'APPLICATION_SECRET'
   faraday.request :panoptes_api_v1
   faraday.response :json
+
+  faraday.adapter Faraday.default_adapter # WITHOUT THIS LINE NOTHING WILL HAPPEN
 end
 
 response = api_client.get("/api/projects/1")
@@ -35,9 +35,23 @@ Or install it yourself as:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+Use docker & compose to setup the dev env
+
+```shell
+$ docker-compose build
+```
+
+Run a bash shell inside the new container
+
+```shell
+$ docker-compose run --service-ports --rm faraday-panoptes bash
+```
+
+To run the tests you will have to configure the ENV variables in
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  faraday-panoptes:
+    build:
+      context: .
+    volumes:
+      - ./:/app
+      - gem_cache:/usr/local/bundle
+
+volumes:
+  gem_cache:

--- a/faraday-panoptes.gemspec
+++ b/faraday-panoptes.gemspec
@@ -22,11 +22,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.10'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "openssl"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "jwt"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,8 +101,8 @@ def auth_request(faraday, auth)
 end
 
 def configure(faraday)
-  faraday.adapter Faraday.default_adapter
   faraday.request :panoptes_api_v1
   faraday.request :json
   faraday.response :json
+  faraday.adapter Faraday.default_adapter
 end


### PR DESCRIPTION
This PR updates the repo gem env and longer term to allow easier maintenance
- adds a dockerized dev env 
- upgrades gems including bundler and rake others
- switches from travis to github actions CI runner
- updates the faraday test adapter and middleware config (and readme examples)