### PR TITLE
Relax faraday gem deps

### DIFF
--- a/faraday-panoptes.gemspec
+++ b/faraday-panoptes.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday', '~> 0.9'
-  spec.add_dependency 'faraday_middleware', '~> 0.10'
+  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday_middleware', '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "openssl"


### PR DESCRIPTION
relax the gem constraints to allow this to work with updated faraday >= v1 installs

However we do not want bump past v1 faraday to v2 as it has a lot of breaking changes including deprecating the middleware gem**. It's not a big problem just requires work reorganizing the setup and testing things work again.

** moving to explicit gem inclusion vs a wrapper gem of default offerings.